### PR TITLE
Feature/fail loudly

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -7,3 +7,4 @@ authors = ["amanjpro <http://www.amanj.me>"]
 serde = "1.0"
 serde_derive = "1.0"
 rust-ini = "0.10"
+docopt = "0.8"

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -13,7 +13,6 @@ pub struct Mail {
 
 const DEFAULT_HEARTBEAT_IN_MINUTES: u8 = 3;
 
-#[derive(Clone)]
 pub struct Configuration {
     pub passwordeval: String,
     pub smtpclient: Option<String>,

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -80,3 +80,5 @@ pub fn read_config(rc_path: &str) -> Configuration {
 }
 
 pub static SOCKET_PATH: &'static str = "smtp-daemon-socket";
+pub static OK_SIGNAL: &'static str = "OK";
+pub static ERROR_SIGNAL: &'static str = "ERROR";

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -13,6 +13,7 @@ pub struct Mail {
 
 const DEFAULT_HEARTBEAT_IN_MINUTES: u8 = 3;
 
+#[derive(Clone)]
 pub struct Configuration {
     pub passwordeval: String,
     pub smtpclient: Option<String>,

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -143,14 +143,14 @@ pub fn smtpc_usage(app_name: &str) -> String {
 
 pub fn process_args(app_name: &str, usage: &str) -> Args {
 
-    let APP_VERSION = env!("CARGO_PKG_VERSION");
+    let app_version = env!("CARGO_PKG_VERSION");
 
     let args: Args = Docopt::new(usage.clone())
         .and_then(|d| d.deserialize())
         .unwrap_or_else(|e| e.exit());
 
     if args.flag_version {
-        println!("{}, v {}", app_name, APP_VERSION);
+        println!("{}, v {}", app_name, app_version);
         exit(0);
     }
 

--- a/esmtp-client/src/lib.rs
+++ b/esmtp-client/src/lib.rs
@@ -6,7 +6,7 @@ extern crate base64;
 
 use verbs::*;
 use secstr::SecStr;
-use base64::{encode, decode};
+use base64::encode;
 use std::io::prelude::*;
 use native_tls::{TlsConnector, TlsStream};
 use std::net::{TcpStream, ToSocketAddrs, IpAddr};

--- a/main/Cargo.toml
+++ b/main/Cargo.toml
@@ -12,7 +12,6 @@ name = "smtpc"
 path = "src/smtpc.rs"
 
 [dependencies]
-docopt = "0.8"
 secstr = "0.3.0"
 serde = "1.0"
 serde_derive = "1.0"

--- a/main/Cargo.toml
+++ b/main/Cargo.toml
@@ -13,8 +13,6 @@ path = "src/smtpc.rs"
 
 [dependencies]
 secstr = "0.3.0"
-serde = "1.0"
-serde_derive = "1.0"
 serde_json = "1.0.9"
 common = { path = "../common" }
 esmtp_client = { path = "../esmtp-client" }

--- a/main/src/smtpc.rs
+++ b/main/src/smtpc.rs
@@ -5,6 +5,7 @@ extern crate common;
 
 use std::os::unix::net::UnixStream;
 use std::process::exit;
+use std::net::Shutdown;
 use std::time::Duration;
 use common::{SOCKET_PATH, ERROR_SIGNAL, OK_SIGNAL, Mail, process_args};
 use std::env;
@@ -32,7 +33,7 @@ fn main () {
 
     let mut stream = UnixStream::connect(SOCKET_PATH).expect("The daemon is not running, please start it.");
     stream.write_all(msg.as_bytes()).unwrap();
-    stream.shutdown(std::net::Shutdown::Write);
+    stream.shutdown(Shutdown::Write);
     let timeout = Duration::new(30, 0);
     let _ = stream.set_read_timeout(Some(timeout));
     let mut response = Vec::new();

--- a/main/src/smtpc.rs
+++ b/main/src/smtpc.rs
@@ -4,7 +4,8 @@ extern crate common;
 
 
 use std::os::unix::net::UnixStream;
-use common::{SOCKET_PATH, Mail};
+use std::process::exit;
+use common::{SOCKET_PATH, ERROR_SIGNAL, OK_SIGNAL, Mail};
 use std::env;
 use std::io::{self, Read, Write};
 
@@ -26,4 +27,12 @@ fn main () {
 
     let mut stream = UnixStream::connect(SOCKET_PATH).expect("The daemon is not running, please start it.");
     stream.write_all(msg.as_bytes()).unwrap();
+    let mut response = String::new();
+    let _ = stream.read_to_string(&mut response);
+    if &response == ERROR_SIGNAL { exit(1); }
+    else if &response == OK_SIGNAL { exit(0); }
+    else {
+        println!("Unexpected response from the server: {}", response);
+        exit(1);
+    }
 }

--- a/main/src/smtpc.rs
+++ b/main/src/smtpc.rs
@@ -5,6 +5,7 @@ extern crate common;
 
 use std::os::unix::net::UnixStream;
 use std::process::exit;
+use std::time::Duration;
 use common::{SOCKET_PATH, ERROR_SIGNAL, OK_SIGNAL, Mail};
 use std::env;
 use std::io::{self, Read, Write};
@@ -26,6 +27,8 @@ fn main () {
         .expect("Cannot generate JSON for the given message");
 
     let mut stream = UnixStream::connect(SOCKET_PATH).expect("The daemon is not running, please start it.");
+    let timeout = Duration::new(5, 0);
+    let _ = stream.set_read_timeout(Some(timeout));
     stream.write_all(msg.as_bytes()).unwrap();
     let mut response = String::new();
     let _ = stream.read_to_string(&mut response);

--- a/main/src/smtpc.rs
+++ b/main/src/smtpc.rs
@@ -7,7 +7,6 @@ use std::process::exit;
 use std::net::Shutdown;
 use std::time::Duration;
 use common::*;
-use std::env;
 use std::io::{self, Read, Write};
 
 fn main () {
@@ -28,8 +27,8 @@ fn main () {
         .expect("Cannot generate JSON for the given message");
 
     let mut stream = UnixStream::connect(SOCKET_PATH).expect("The daemon is not running, please start it.");
-    stream.write_all(msg.as_bytes()).unwrap();
-    stream.shutdown(Shutdown::Write);
+    let _ = stream.write_all(msg.as_bytes()).unwrap();
+    let _ = stream.shutdown(Shutdown::Write);
     let timeout = Duration::new(conf.timeout, 0);
     let _ = stream.set_read_timeout(Some(timeout));
     let mut response = Vec::new();

--- a/main/src/smtpc.rs
+++ b/main/src/smtpc.rs
@@ -1,4 +1,3 @@
-extern crate serde;
 extern crate serde_json;
 extern crate common;
 

--- a/main/src/smtpc.rs
+++ b/main/src/smtpc.rs
@@ -6,12 +6,16 @@ extern crate common;
 use std::os::unix::net::UnixStream;
 use std::process::exit;
 use std::time::Duration;
-use common::{SOCKET_PATH, ERROR_SIGNAL, OK_SIGNAL, Mail};
+use common::{SOCKET_PATH, ERROR_SIGNAL, OK_SIGNAL, Mail, process_args};
 use std::env;
 use std::io::{self, Read, Write};
 
 fn main () {
+
+    let conf = process_args("smtpc");
+
     let mut full_args: Vec<String> = env::args().collect();
+
     full_args.remove(0);
 
     let mut body: Vec<u8> = Vec::new();

--- a/main/src/smtpd.rs
+++ b/main/src/smtpd.rs
@@ -50,7 +50,7 @@ fn external_smtp_client(client: &str, passwd: &SecStr) {
     if let Ok(listener) = UnixListener::bind(SOCKET_PATH) {
         for stream in listener.incoming() {
             match stream {
-                Ok(mut stream) => {
+                Ok(stream) => {
                   send_mail_with_external_client(stream, &client, &passwd);
                 }
                 _              => {
@@ -75,7 +75,7 @@ fn default_smtp_client(conf: Configuration, passwd: &mut SecStr) {
         mailer.login(&SecStr::from(username.clone()), &passwd);
     }
 
-    let mut mailer = Arc::new(Mutex::new(mailer));
+    let mailer = Arc::new(Mutex::new(mailer));
 
     {
         let mailer = mailer.clone();

--- a/main/src/smtpd.rs
+++ b/main/src/smtpd.rs
@@ -1,11 +1,7 @@
-extern crate serde;
 extern crate serde_json;
 extern crate common;
 extern crate secstr;
 extern crate esmtp_client;
-
-#[macro_use]
-extern crate serde_derive;
 
 use secstr::SecStr;
 use common::{SOCKET_PATH, OK_SIGNAL, ERROR_SIGNAL, Mail, Configuration, process_args};

--- a/main/src/smtpd.rs
+++ b/main/src/smtpd.rs
@@ -34,7 +34,7 @@ struct Args {
     flag_version: bool,
 }
 
-fn send_mail(mut stream: UnixStream, client: &str, passwd: &SecStr) {
+fn send_mail_with_external_client(mut stream: UnixStream, client: &str, passwd: &SecStr) {
     let mut mail = String::new();
     stream.read_to_string(&mut mail).unwrap();
     let mail: Mail = serde_json::from_str(&mail).expect("Cannot parse the mail");
@@ -60,7 +60,7 @@ fn external_smtp_client(client: &str, passwd: &SecStr) {
         for stream in listener.incoming() {
             match stream {
                 Ok(mut stream) => {
-                  send_mail(stream, &client, &passwd);
+                  send_mail_with_external_client(stream, &client, &passwd);
                 }
                 Err(err) => {
                     /* connection failed */

--- a/main/src/smtpd.rs
+++ b/main/src/smtpd.rs
@@ -4,7 +4,7 @@ extern crate secstr;
 extern crate esmtp_client;
 
 use secstr::SecStr;
-use common::{SOCKET_PATH, OK_SIGNAL, ERROR_SIGNAL, Mail, Configuration, process_args};
+use common::*;
 use esmtp_client::SMTPConnection;
 
 use std::os::unix::net::{UnixStream, UnixListener};
@@ -140,7 +140,8 @@ fn start_daemon(conf: Configuration) {
 
 fn main() {
 
-    let conf = process_args("smtpd");
+    let args = process_args("smtpd", &smtpd_usage("smptd"));
+    let conf = read_config(&args.flag_smtpdrc);
 
     start_daemon(conf);
 }

--- a/main/src/smtpd.rs
+++ b/main/src/smtpd.rs
@@ -123,7 +123,7 @@ fn default_smtp_client(conf: Configuration, passwd: &mut SecStr) {
 }
 
 fn start_daemon(conf: Configuration) {
-    let eval = &conf.passwordeval;
+    let eval = &conf.passwordeval.clone();
     let client = conf.smtpclient.clone();
 
     if let Ok(result) = Command::new("sh").arg("-c").arg(eval).stdout(Stdio::piped()).spawn() {
@@ -138,11 +138,10 @@ fn start_daemon(conf: Configuration) {
         fs::remove_file(SOCKET_PATH);
 
         match client {
-
             Some(client) =>
                 external_smtp_client(&client, &passwd),
             None         =>
-                default_smtp_client(conf.to_owned(), &mut passwd),
+                default_smtp_client(conf, &mut passwd),
         }
     }
 }

--- a/smtpdrc.default
+++ b/smtpdrc.default
@@ -3,6 +3,9 @@ passwordeval=echo password
 # custom smtp clients
 # smtp=/path/to/custom/smtp/client
 
+[Client]
+timeout=30
+
 [SMTP]
 host=smtp.gmail.com
 username=username@gmail.com


### PR DESCRIPTION
If the smtpc fail loudly (i.e. exit with 1 upon mail sending failure), we give the email client a chance to retry to send the email again later.